### PR TITLE
URI encode `savedSelector`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Generate [Internet Archive (IA) credentials](https://archive.org/developers/tuto
 Specify your IA credentials as [GitHub repository secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) in your forked repository.
 
 The secrets should be named:
-SAVEPAGENOW_ACCESS_KEY
-SAVEPAGENOW_SECRET_KEY
+```SAVEPAGENOW_ACCESS_KEY```
+```SAVEPAGENOW_SECRET_KEY```
 
 Enable GitHub action workflows on your fork (navigate to "Actions" on the repository and enable)
 Follow the [DocumentCloud Add-On instructions](https://github.com/MuckRock/documentcloud-hello-world-addon/wiki/#run-your-add-on-in-documentcloud) to authorize your forked add-on within DocumentCloud.

--- a/README.md
+++ b/README.md
@@ -47,4 +47,7 @@ Note that Klaxon relies on [savepagenow](https://pypi.org/project/savepagenow/),
 The MuckRock version of Klaxon has a higher rate limit, so if you plan on running your own version of Klaxon with a lot of users running hourly checks, you may eventually hit rate limits. 
 Klaxon does use [tenacity](https://pypi.org/project/tenacity/) for exponential back-offs on retries for the savepagenow captures, but under high usage, it is still possible for the low default rate limits to cause issues, especially if users are monitoring sites without applying a filter for trivial changes. 
 
-
+# Acknowledgements 
+* The Marshall Project Team (especially Tom Meagher)
+* The Internet Archive Team (especially Vangelis Banos & Mark Graham)
+* Gregory Foster

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Next, publish the bookmarklet to a publicly accessible location (e.g. S3, GCS, y
 Modify bookmarklet/inject.js to replace all three of the klaxon.html references at the [top of the file](https://github.com/MuckRock/Klaxon/blob/89df26a6ea4433765cc3402c76335b9209cd4e90/bookmarklet/inject.js#L2) with your own. <br>
 Publish the Javascript inject.js file to a publcly accessible location. <br>
 
-Finally, modify the bookmarklet code in your browser (or create a separate bookmarklet) to reference your custom inject.js file instead. <br>
+Finally, modify the bookmarklet code in your browser (or create a separate bookmarklet) to reference your custom inject.js file instead. <br> <br>
 
-Your "Add to Klaxon" bookmarklet will now work the same but send monitoring jobs to your forked add-on instead of the default MuckRock add-on. <br>
+Your "Add to Klaxon" bookmarklet will now work the same but send monitoring jobs to your forked add-on instead of the default MuckRock add-on. <br> <br>
 
 # Notes on rate-limiting
 

--- a/README.md
+++ b/README.md
@@ -24,27 +24,27 @@ The secrets should be named:
 ```SAVEPAGENOW_ACCESS_KEY```
 ```SAVEPAGENOW_SECRET_KEY```
 
-Enable GitHub action workflows on your fork (navigate to "Actions" on the repository and enable)
-Follow the [DocumentCloud Add-On instructions](https://github.com/MuckRock/documentcloud-hello-world-addon/wiki/#run-your-add-on-in-documentcloud) to authorize your forked add-on within DocumentCloud.
+Enable GitHub action workflows on your fork (navigate to "Actions" on the repository and enable). <br>
+Follow the [DocumentCloud Add-On instructions](https://github.com/MuckRock/documentcloud-hello-world-addon/wiki/#run-your-add-on-in-documentcloud) to authorize your forked add-on within DocumentCloud. <br>
 
-At this point, the forked add-on will appear when you browse in DC, but will be identically named; you can distinguish your version by looking at "Created By" when opening the add-on or check the URI fragment.
-You can manually configure monitoring tasks from within DC, which will trigger the action to run from your forked repository with your IA credentials.
+At this point, the forked add-on will appear when you browse in DC, but will be identically named; you can distinguish your version by looking at "Created By" when opening the add-on or check the URI fragment. <br>
+You can manually configure monitoring tasks from within DC, which will trigger the action to run from your forked repository with your IA credentials. <br>
 
-You will also want to modify the bookmarklet to point to your repository. 
-Modify bookmarklet/klaxon.html to target your forked add-on when your browser session is redirected to DC to specify the rest of the monitoring parameters.  Just change the repo name on line 171 to yours. 
+You will also want to modify the bookmarklet to point to your repository. <br>
+Modify bookmarklet/klaxon.html to target your forked add-on when your browser session is redirected to DC to specify the rest of the monitoring parameters.  Just change the repo name on line 171 to yours. <br>
 
-Publish the bookmarklet to a publicly accessible location (e.g. S3, GCS, your website) and copy the URL to the resource.
-Modify bookmarklet/inject.js to replace all three of the klaxon.html references at the [top of the file](https://github.com/MuckRock/Klaxon/blob/89df26a6ea4433765cc3402c76335b9209cd4e90/bookmarklet/inject.js#L2) with your own. 
-Publish the Javascript inject.js file to a publcly accessible location. 
+Next, publish the bookmarklet to a publicly accessible location (e.g. S3, GCS, your website) and copy the URL to the resource. <br>
+Modify bookmarklet/inject.js to replace all three of the klaxon.html references at the [top of the file](https://github.com/MuckRock/Klaxon/blob/89df26a6ea4433765cc3402c76335b9209cd4e90/bookmarklet/inject.js#L2) with your own. <br>
+Publish the Javascript inject.js file to a publcly accessible location. <br>
 
-Finally, modify the bookmarklet code in your browser (or create a separate bookmarklet) to reference your custom inject.js file instead.
+Finally, modify the bookmarklet code in your browser (or create a separate bookmarklet) to reference your custom inject.js file instead. <br>
 
-Your "Add to Klaxon" bookmarklet will now work the same but send monitoring jobs to your forked add-on instead of the default MuckRock add-on.
+Your "Add to Klaxon" bookmarklet will now work the same but send monitoring jobs to your forked add-on instead of the default MuckRock add-on. <br>
 
 # Notes on rate-limiting
 
-Note that Klaxon relies on savepagenow, a Python library that interacts with the Internet Archive's Wayback Machine. Even authenticated requests with savepagenow are limited to 6 requests/minute. 
+Note that Klaxon relies on [savepagenow](https://pypi.org/project/savepagenow/), a Python library that interacts with the Internet Archive's Wayback Machine. Even authenticated requests with savepagenow are limited to [6 requests/minute](https://palewi.re/docs/savepagenow/python.html#authentication). 
 The MuckRock version of Klaxon has a higher rate limit, so if you plan on running your own version of Klaxon with a lot of users running hourly checks, you may eventually hit rate limits. 
-Klaxon does use tenacity for exponential back-offs for the savepagenow captures, but under high usage, it is still possible for the low default rate limits to cause issues, especially if users are monitoring sites without applying a filter for trivial changes. 
+Klaxon does use [tenacity](https://pypi.org/project/tenacity/) for exponential back-offs on retries for the savepagenow captures, but under high usage, it is still possible for the low default rate limits to cause issues, especially if users are monitoring sites without applying a filter for trivial changes. 
 
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ and then save it to your bookmarks. Visit a page you want to monitor and click o
 Fork this repository.
 Generate [Internet Archive (IA) credentials](https://archive.org/developers/tutorial-get-ia-credentials.html)
 
-https://archive.org/account/s3.php
-
 Specify your IA credentials as [GitHub repository secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) in your forked repository.
 
 The secrets should be named:

--- a/README.md
+++ b/README.md
@@ -12,3 +12,41 @@ To get started with Klaxon, copy the following code to a new bookmark:
 ```javascript:(function(){document.body.appendChild(document.createElement('script')).src='https://documentcloud-klaxon.s3.amazonaws.com/inject.js';})();```
 
 and then save it to your bookmarks. Visit a page you want to monitor and click on the bookmarklet to activate Klaxon. 
+
+# Running your own fork of Klaxon
+
+Fork this repository.
+Generate [Internet Archive (IA) credentials](https://archive.org/developers/tutorial-get-ia-credentials.html)
+
+https://archive.org/account/s3.php
+
+Specify your IA credentials as [GitHub repository secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) in your forked repository.
+
+The secrets should be named:
+SAVEPAGENOW_ACCESS_KEY
+SAVEPAGENOW_SECRET_KEY
+
+Enable GitHub action workflows on your fork (navigate to "Actions" on the repository and enable)
+Follow the [DocumentCloud Add-On instructions](https://github.com/MuckRock/documentcloud-hello-world-addon/wiki/#run-your-add-on-in-documentcloud) to authorize your forked add-on within DocumentCloud.
+
+At this point, the forked add-on will appear when you browse in DC, but will be identically named; you can distinguish your version by looking at "Created By" when opening the add-on or check the URI fragment.
+You can manually configure monitoring tasks from within DC, which will trigger the action to run from your forked repository with your IA credentials.
+
+You will also want to modify the bookmarklet to point to your repository. 
+Modify bookmarklet/klaxon.html to target your forked add-on when your browser session is redirected to DC to specify the rest of the monitoring parameters.  Just change the repo name on line 171 to yours. 
+
+Publish the bookmarklet to a publicly accessible location (e.g. S3, GCS, your website) and copy the URL to the resource.
+Modify bookmarklet/inject.js to replace all three of the klaxon.html references at the [top of the file](https://github.com/MuckRock/Klaxon/blob/89df26a6ea4433765cc3402c76335b9209cd4e90/bookmarklet/inject.js#L2) with your own. 
+Publish the Javascript inject.js file to a publcly accessible location. 
+
+Finally, modify the bookmarklet code in your browser (or create a separate bookmarklet) to reference your custom inject.js file instead.
+
+Your "Add to Klaxon" bookmarklet will now work the same but send monitoring jobs to your forked add-on instead of the default MuckRock add-on.
+
+# Notes on rate-limiting
+
+Note that Klaxon relies on savepagenow, a Python library that interacts with the Internet Archive's Wayback Machine. Even authenticated requests with savepagenow are limited to 6 requests/minute. 
+The MuckRock version of Klaxon has a higher rate limit, so if you plan on running your own version of Klaxon with a lot of users running hourly checks, you may eventually hit rate limits. 
+Klaxon does use tenacity for exponential back-offs for the savepagenow captures, but under high usage, it is still possible for the low default rate limits to cause issues, especially if users are monitoring sites without applying a filter for trivial changes. 
+
+

--- a/bookmarklet/inject.js
+++ b/bookmarklet/inject.js
@@ -59,7 +59,7 @@
 
   var src = editorURL + "?url=" + encodeURIComponent(getCanonicalURL());
   var iframe = document.createElement('iframe');
-  // iframe.setAttribute('src', src);
+  iframe.setAttribute('src', src);
   iframe.setAttribute('id', 'klaxon-bookmarklet-iframe');
   iframe.setAttribute('frameborder', 0);
   iframe.style.top = '0px';

--- a/bookmarklet/klaxon.html
+++ b/bookmarklet/klaxon.html
@@ -168,7 +168,7 @@
 
       document.getElementById("edit-button").addEventListener('click', function(e) {
         const urlParams = new URLSearchParams(location.search);
-        window.open(`https://www.documentcloud.org/app?q=%2B` + `&site=${urlParams.get("url")}&selector=${savedSelector}&event=hourly` + '#add-ons/MuckRock/Klaxon');
+        window.open(`https://www.documentcloud.org/add-ons/MuckRock/Klaxon/?site=${urlParams.get("url")}&selector=${savedSelector}&event=hourly`);
       }, false);
 
 

--- a/bookmarklet/klaxon.html
+++ b/bookmarklet/klaxon.html
@@ -168,7 +168,8 @@
 
       document.getElementById("edit-button").addEventListener('click', function(e) {
         const urlParams = new URLSearchParams(location.search);
-        window.open(`https://www.documentcloud.org/add-ons/MuckRock/Klaxon/?site=${urlParams.get("url")}&selector=${savedSelector}&event=hourly`);
+        const selector = encodeURIComponent(savedSelector);
+        window.open(`https://www.documentcloud.org/add-ons/MuckRock/Klaxon/?site=${urlParams.get("url")}&selector=${selector}&event=hourly`);
       }, false);
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ properties:
   filter_selector:
     title: Filter
     type: string
-    description: 'Optional HTML tag that you want to filter out from being compared. Ex: Type a for <a> tags'
+    description: 'Optional HTML tag that you want to filter out from being compared. Ex: Type <code>a</code> for <code>&lt;a&gt;</code> tags'
   slack_webhook:
     title: Slack Webhook
     type: string


### PR DESCRIPTION
Fixes #19 by ensuring selectors containing IDs get encoded correctly into the URL